### PR TITLE
Fix for config file parameter is not used

### DIFF
--- a/src/main/java/org/walkmod/WalkModFacade.java
+++ b/src/main/java/org/walkmod/WalkModFacade.java
@@ -278,8 +278,7 @@ public class WalkModFacade {
 		if (options.containsKey(Options.EXCLUDES))
 			this.includes = ((List<String>) options.get(Options.EXCLUDES)).toArray(new String[]{});
 
-		if (walkmodCfg != null)
-			this.cfg = new File(DEFAULT_WALKMOD_FILE);
+		this.cfg = (walkmodCfg != null) ? walkmodCfg : new File(DEFAULT_WALKMOD_FILE);
 
 		if (configurationProvider != null)
 			this.configurationProvider = configurationProvider;


### PR DESCRIPTION
The config file parameter which is passed in the constructor has no effect, the default file is always used.
