### PR TITLE
Improve FileResourceTest readabilty with Hamcrest and fix Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+			<version>2.6</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-all</artifactId>
 			<version>1.3</version>

--- a/src/test/java/org/walkmod/util/FileResourceTest.java
+++ b/src/test/java/org/walkmod/util/FileResourceTest.java
@@ -1,135 +1,135 @@
 package org.walkmod.util;
 
+import org.junit.Assert;
+import org.junit.Test;
+import org.walkmod.utils.TestUtils;
+
 import java.io.File;
 import java.util.Iterator;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 public class FileResourceTest {
+
+    private static final String SOURCES_PATH = "src/main/java";
 
 	@Test
 	public void testIncludes() {
 		FileResource fr = new FileResource();
-		fr.setPath("src/main/java");
+		fr.setPath(SOURCES_PATH);
 		String file = "org/walkmod/util/FileResource.java";
 		fr.setIncludes(new String[] { file });
 		File filter = new File("src/main/java/" + file);
 		Iterator<File> it = fr.iterator();
 		File f = it.next();
-		Assert.assertEquals(filter.getAbsolutePath(), f.getAbsolutePath());
-		Assert.assertEquals(false, it.hasNext());
+		assertThat(f.getAbsolutePath(), equalTo(filter.getAbsolutePath()));
+        assertThat(it.hasNext(), is(false));
 	}
 
 	@Test
 	public void testIncludes2() {
 		FileResource fr = new FileResource();
-		File aux = new File("src/main/java");
-		fr.setPath("src/main/java");
-		String file = new File(aux, "org/walkmod/util").getAbsolutePath();
-		fr.setIncludes(new String[] { file });
-		File filter = new File(file);
-		Iterator<File> it = fr.iterator();
+        fr.setPath(SOURCES_PATH);
+		String file = new File(new File("src/main/java"), "org/walkmod/util").getAbsolutePath();
+		fr.setIncludes(new String[]{file});
+
+        File filter = new File(file);
+        Iterator<File> it = fr.iterator();
 		File f = it.next();
-		Assert.assertTrue(f.getAbsolutePath().startsWith(
-				filter.getAbsolutePath()));
+        assertThat(f.getAbsolutePath(), startsWith(filter.getAbsolutePath()));
 
 	}
 
 	@Test
 	public void testIncludesWildcard() {
 		FileResource fr = new FileResource();
-		fr.setPath("src/main/java");
+		fr.setPath(SOURCES_PATH);
 		String file = "org/walkmod/util";
 		fr.setIncludes(new String[] { file });
 		File filter = new File("src/main/java/" + file);
 		Iterator<File> it = fr.iterator();
 		File f = it.next(); 
-		Assert.assertTrue(f.getAbsolutePath().startsWith(
-				filter.getAbsolutePath()));
+		assertThat(f.getAbsolutePath(), startsWith(filter.getAbsolutePath()));
 
 	}
 
 	@Test
 	public void testIncludesWildcard2() {
 		FileResource fr = new FileResource();
-		fr.setPath("src/main/java");
+		fr.setPath(SOURCES_PATH);
 		String file = "org/walkmod/util";
 		fr.setIncludes(new String[] { file + "/*" });
 		File filter = new File("src/main/java/" + file);
 		Iterator<File> it = fr.iterator();
 		File f = it.next();
-		Assert.assertTrue(f.getAbsolutePath().startsWith(
-				filter.getAbsolutePath()));
+        assertThat(f.getAbsolutePath(), startsWith(filter.getAbsolutePath()));
 	}
 
 	@Test
 	public void testIncludesWildcard3() {
 		FileResource fr = new FileResource();
-		fr.setPath("src/main/java");
+		fr.setPath(SOURCES_PATH);
 		String file = "org/walkmod";
 		fr.setIncludes(new String[] { file + "/**" });
 
 		Iterator<File> it = fr.iterator();
-		Assert.assertTrue(it.hasNext());
+        assertThat(it.hasNext(), is(true));
 		File result = it.next();
-		Assert.assertTrue(result.getAbsolutePath().contains(
-				"src/main/java/org/walkmod"));
+        String osDependentPath = TestUtils.buildPath("src","main","java","org","walkmod");
+        assertThat(result.getAbsolutePath(), containsString(osDependentPath));
 	}
 
 	@Test
 	public void testExcludes() {
 		FileResource fr = new FileResource();
-		fr.setPath("src/main/java");
+		fr.setPath(SOURCES_PATH);
 		String file = "org/walkmod/util/FileResource.java";
-		fr.setExcludes(new String[] { file });
+		fr.setExcludes(new String[] { file});
 
-		Iterator<File> it = fr.iterator();
-		Assert.assertTrue(it.hasNext());
-		File f = it.next();
-		Assert.assertTrue(!f.getAbsolutePath().contains(
-				"org/walkmod/util/FileResource.java"));
-
+        Iterator<File> it = fr.iterator();
+        Assert.assertTrue(it.hasNext());
+        File f = it.next();
+        String osDependentPath = TestUtils.buildPath("org","walkmod","util","FileResource.java");
+		assertThat(f.getAbsolutePath(), not(containsString(osDependentPath)));
 	}
 
 	@Test
 	public void testExcludesWildcard() {
 		FileResource fr = new FileResource();
-		fr.setPath("src/main/java");
+		fr.setPath(SOURCES_PATH);
 		String file = "org/walkmod/util";
-		fr.setExcludes(new String[] { file });
-		Iterator<File> it = fr.iterator();
-		Assert.assertTrue(it.hasNext());
+		fr.setExcludes(new String[] { file});
+        Iterator<File> it = fr.iterator();
+        Assert.assertTrue(it.hasNext());
 		File f = it.next();
-		Assert.assertTrue(!f.getAbsolutePath().contains("org/walkmod/util"));
-
+        String osDependentPath = TestUtils.buildPath("org","walkmod","util");
+		assertThat(f.getAbsolutePath(), not(containsString(osDependentPath)));
 	}
 
 	@Test
 	public void testExcludesWildcard2() {
 		FileResource fr = new FileResource();
-		fr.setPath("src/main/java");
+		fr.setPath(SOURCES_PATH);
 		String file = "org/walkmod/util";
 		fr.setExcludes(new String[] { file + "/*" });
 
-		Iterator<File> it = fr.iterator();
-		Assert.assertTrue(it.hasNext());
+        Iterator<File> it = fr.iterator();
+        Assert.assertTrue(it.hasNext());
 		File f = it.next();
-		Assert.assertTrue(!f.getAbsolutePath().contains("org/walkmod/util"));
-
+        String osDependentPath = TestUtils.buildPath("org","walkmod","util");
+		assertThat(f.getAbsolutePath(), not(containsString(osDependentPath)));
 	}
 
 	@Test
 	public void testExcludesWildcard3() {
 		FileResource fr = new FileResource();
-		fr.setPath("src/main/java");
+		fr.setPath(SOURCES_PATH);
 		String file = "org/walkmod";
 		fr.setExcludes(new String[] { file + "/**" });
 
 		Iterator<File> it = fr.iterator();
-
-		Assert.assertTrue(!it.hasNext());
-
+		assertThat(it.hasNext(), is(false));
 	}
 
 }

--- a/src/test/java/org/walkmod/utils/TestUtils.java
+++ b/src/test/java/org/walkmod/utils/TestUtils.java
@@ -1,6 +1,8 @@
 package org.walkmod.utils;
 
+import org.apache.commons.lang.StringUtils;
 import org.walkmod.WalkModFacade;
+import sun.swing.StringUIClientPropertyKey;
 
 import java.lang.reflect.Field;
 
@@ -46,5 +48,17 @@ public class TestUtils {
         } catch (IllegalAccessException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Builds a path taking into consideration the particularities of the host
+     * OS (e.g. uses System.getProperty("file.separator")).
+     *
+     * @param components list of elements that constitute the path
+     *
+     * @return An OS dependant path
+     */
+    public static String buildPath(String... components) {
+        return StringUtils.join(components, FILE_SEPARATOR);
     }
 }


### PR DESCRIPTION
This PR includes:

* Fixes for some test that failed when validating paths in Windows
* Some test have been rewritten to Hamcrest since it offers better messages when a test fails