### PR TITLE
Simplification in the Options management

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,8 +1,12 @@
+:project-full-path: rpau/walkmod-core
+
 walkmod-core
 ============
 Raquel Pau <raquelpau@gmail.com>
 
 image:https://travis-ci.org/rpau/walkmod-core.svg?branch=master["Build Status", link="https://travis-ci.org/rpau/walkmod-core"]
+
+image:https://badges.gitter.im/Join Chat.svg["Chat",link="https://gitter.im/{project-full-path}?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
 
 This project, called http://www.walkmod.com[walkmod], is an open source tool to apply coding conventions. Walkmod can support with 
 any programing language if a set of interfaces are implemented as a third party plugin. The first (and current)
@@ -24,7 +28,7 @@ You just need the following dependency:
 <dependency>
     <groupId>org.walkmod</groupId>
     <artifactId>walkmod-core</artifactId>
-    <version>1.0.6</version>
+    <version>1.3.0</version>
 </dependency>
 ----
 

--- a/src/main/java/org/walkmod/Options.java
+++ b/src/main/java/org/walkmod/Options.java
@@ -11,93 +11,151 @@ import java.util.*;
  */
 public class Options {
 
-    /**
-     * (Boolean) Disables/enables remote fetching of plugins
-     */
-    public static final String OFFLINE = "offline";
-    /**
-     * (Boolean) Disables/enables info messages in the console
-     */
-    public static final String VERBOSE = "verbose";
-    /**
-     * (Boolean) Disables/enables error messages in the console
-     */
-    public static final String PRINT_ERRORS = "print_errors";
-    /**
-     * (Boolean) Disables/enables the capture of original exceptions (requires verbose = true)
-     */
-    public static final String THROW_EXCEPTION = "throw_exception";
-    /**
-     * (List&lt;String&gt;) Overwrites the include rules in the chain's reader
-     */
-    public static final String INCLUDES = "includes";
-    /**
-     * (List&lt;String&gt;) Overwrites the exclude rules in the chain's reader
-     */
-    public static final String EXCLUDES = "excludes";
+	/**
+	 * (Boolean) Disables/enables remote fetching of plugins
+	 */
+	public static final String OFFLINE = "offline";
+	/**
+	 * (Boolean) Disables/enables info messages in the console
+	 */
+	public static final String VERBOSE = "verbose";
+	/**
+	 * (Boolean) Disables/enables error messages in the console
+	 */
+	public static final String PRINT_ERRORS = "print_errors";
+	/**
+	 * (Boolean) Disables/enables the capture of original exceptions (requires
+	 * verbose = true)
+	 */
+	public static final String THROW_EXCEPTION = "throw_exception";
+	/**
+	 * (List&lt;String&gt;) Overwrites the include rules in the chain's reader
+	 */
+	public static final String INCLUDES = "includes";
+	/**
+	 * (List&lt;String&gt;) Overwrites the exclude rules in the chain's reader
+	 */
+	public static final String EXCLUDES = "excludes";
 
-    /**
-     * Stored options
-     */
-    private Map<String, Object> options = new HashMap<String, Object>();
+	/**
+	 * Stored options
+	 */
+	private Map<String, Object> options = new HashMap<String, Object>();
 
-    /**
-     * Creates an empty set of options
-     */
-    public Options() {
-    }
+	/**
+	 * Creates an empty set of options
+	 */
+	public Options() {
+		this(null);
+	}
 
-    /**
-     * Creates a set of options with initialized values
-     *
-     * @param options Already initialized options
-     */
-    public Options(Map<String, Object> options) {
-        this.options.putAll(options);
-    }
+	/**
+	 * Creates a set of options with initialized values
+	 *
+	 * @param options
+	 *            Already initialized options
+	 */
+	public Options(Map<String, Object> options) {
+		if (options != null) {
+			this.options.putAll(options);
+			if (!options.containsKey(Options.OFFLINE))
+				setOffline(false);
+			if (!options.containsKey(Options.VERBOSE))
+				setVerbose(true);
+			if (!options.containsKey(Options.PRINT_ERRORS))
+				setPrintErrors(false);
+			if (!options.containsKey(Options.THROW_EXCEPTION))
+				setThrowException(false);
+		}
+		else{
+			setOffline(false);
+			setVerbose(true);
+			setPrintErrors(false);
+			setThrowException(false);
+		}
+	}
 
-    public void setOffline(boolean offline) {
-        this.options.put(OFFLINE, Boolean.valueOf(offline));
-    }
+	public void setOffline(boolean offline) {
+		this.options.put(OFFLINE, Boolean.valueOf(offline));
+	}
 
-    public void setVerbose(boolean verbose) {
-        this.options.put(VERBOSE, Boolean.valueOf(verbose));
-    }
+	public boolean isOffline() {
+		Object value = this.options.get(OFFLINE);
+		return value != null && (Boolean) value;
 
-    public void setPrintErrors(boolean printErrors) {
-        this.options.put(PRINT_ERRORS, Boolean.valueOf(printErrors));
-    }
+	}
 
-    public void setThrowException(boolean throwException) {
-        this.options.put(THROW_EXCEPTION, Boolean.valueOf(throwException));
-    }
+	public void setVerbose(boolean verbose) {
+		this.options.put(VERBOSE, Boolean.valueOf(verbose));
+	}
 
-    public void setIncludes(String... includes) {
+	public boolean isVerbose() {
+		Object value = this.options.get(VERBOSE);
+		return value != null && (Boolean) value;
+	}
 
-        if (!this.options.containsKey(INCLUDES)) {
-            this.options.put(INCLUDES, new ArrayList<Object>());
-        }
+	public void setPrintErrors(boolean printErrors) {
+		this.options.put(PRINT_ERRORS, Boolean.valueOf(printErrors));
+	}
 
-        List<Object> allIncludes = (List<Object>) this.options.get(INCLUDES);
-        allIncludes.addAll(Arrays.asList(includes));
-    }
+	public boolean isPrintErrors() {
+		Object value = this.options.get(PRINT_ERRORS);
+		return value != null && (Boolean) value;
+	}
 
-    public void setExcludes(String... excludes) {
+	public void setThrowException(boolean throwException) {
+		this.options.put(THROW_EXCEPTION, Boolean.valueOf(throwException));
+	}
 
-        if (!this.options.containsKey(EXCLUDES)) {
-            this.options.put(EXCLUDES, new ArrayList<Object>());
-        }
+	public boolean isThrowException() {
+		Object value = this.options.get(THROW_EXCEPTION);
+		return value != null && (Boolean) value;
+	}
 
-        List<Object> allIncludes = (List<Object>) this.options.get(EXCLUDES);
-        allIncludes.addAll(Arrays.asList(excludes));
-    }
+	@SuppressWarnings("unchecked")
+	public void setIncludes(String... includes) {
 
-    /**
-     * Returns the stored options as a Map&lt;String,Object&gt;
-     *
-     * @return map with options
-     */
-    public Map<String, Object> asMap() {
-        return this.options;
-    }
+		if (!this.options.containsKey(INCLUDES)) {
+			this.options.put(INCLUDES, new ArrayList<Object>());
+		}
+
+		List<Object> allIncludes = (List<Object>) this.options.get(INCLUDES);
+		allIncludes.addAll(Arrays.asList(includes));
+	}
+
+	@SuppressWarnings("unchecked")
+	public void setExcludes(String... excludes) {
+
+		if (!this.options.containsKey(EXCLUDES)) {
+			this.options.put(EXCLUDES, new ArrayList<Object>());
+		}
+
+		List<Object> allIncludes = (List<Object>) this.options.get(EXCLUDES);
+		allIncludes.addAll(Arrays.asList(excludes));
+	}
+
+	@SuppressWarnings("unchecked")
+	public List<String> getExcludes() {
+		if (options.containsKey(EXCLUDES)) {
+			return (List<String>) options.get(EXCLUDES);
+		}
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	public List<String> getIncludes() {
+		if (options.containsKey(INCLUDES)) {
+			return (List<String>) options.get(INCLUDES);
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the stored options as a Map&lt;String,Object&gt;
+	 *
+	 * @return map with options
+	 */
+	public Map<String, Object> asMap() {
+		return this.options;
+	}
 }

--- a/src/main/java/org/walkmod/OptionsBuilder.java
+++ b/src/main/java/org/walkmod/OptionsBuilder.java
@@ -5,156 +5,161 @@ import java.util.Map;
 /**
  * Helper class to create Walkmod options map.
  *
- * Usage: OptionsBuilder.options.offline(true).includes("src/main","src/test").asMap()
+ * Usage:
+ * OptionsBuilder.options.offline(true).includes("src/main","src/test").asMap()
  *
  * @author abelsromero
  */
 public class OptionsBuilder {
 
-    /**
-     * Options instance
-     */
-    private Options options;
+	/**
+	 * Options instance
+	 */
+	private Options options;
 
-    /**
-     * Creates an OptionBuilder with the default options
-     */
-    private OptionsBuilder() {
-        options = new Options();
-        options.setOffline(false);
-        options.setVerbose(true);
-        options.setPrintErrors(false);
-        options.setThrowException(false);
-    }
+	/**
+	 * Creates an OptionBuilder with the default options
+	 */
+	private OptionsBuilder() {
+		options = new Options();
 
-    /**
-     * Creates an OptionBuilder with the initialization options
-     */
-    private OptionsBuilder(Map<String, Object> options) {
-        this.options = new Options(options);
-        // Check if default values are set
-        if (!options.containsKey(Options.OFFLINE))
-            this.options.setOffline(false);
-        if (!options.containsKey(Options.VERBOSE))
-            this.options.setVerbose(true);
-        if (!options.containsKey(Options.PRINT_ERRORS))
-            this.options.setPrintErrors(false);
-        if (!options.containsKey(Options.THROW_EXCEPTION))
-            this.options.setThrowException(false);
-    }
+	}
 
-    /**
-     * Creates an OptionBuilder instance with the default options:
-     *
-     * <ul>
-     *   <li>offline = false
-     *   <li>verbose = true
-     *   <li>printErrors = false
-     *   <li>throwException = false
-     * </ul>
-     *
-     * @return options builder instance
-     */
-    public static OptionsBuilder options() {
-        return new OptionsBuilder();
-    }
+	/**
+	 * Creates an OptionBuilder with the initialization options
+	 */
+	private OptionsBuilder(Map<String, Object> options) {
+		this.options = new Options(options);
 
-    /**
-     * Creates an OptionBuilder instance with the default options:
-     *
-     * @param options Map of starting options. See {@link Options} for available
-     *                keys
-     *
-     * @return options builder instance
-     */
-    public static OptionsBuilder options(Map<String, Object> options) {
-        return new OptionsBuilder(options);
-    }
+	}
 
-    /**
-     * Sets the offline option
-     *
-     * @param offline true to disable resolution of plugin from remote repositories
-     * @return updated OptionBuilder instance
-     * @see Options#OFFLINE
-     */
-    public OptionsBuilder offline(boolean offline) {
-        options.setOffline(offline);
-        return this;
-    }
+	/**
+	 * Creates an OptionBuilder instance with the default options:
+	 *
+	 * <ul>
+	 * <li>offline = false
+	 * <li>verbose = true
+	 * <li>printErrors = false
+	 * <li>throwException = false
+	 * </ul>
+	 *
+	 * @return options builder instance
+	 */
+	public static OptionsBuilder options() {
+		return new OptionsBuilder();
+	}
 
-    /**
-     * Sets the verbose option
-     *
-     * @param verbose true to enable info messages in the console
-     * @return updated OptionBuilder instance
-     *
-     * @see Options#VERBOSE
-     */
-    public OptionsBuilder verbose(boolean verbose) {
-        options.setVerbose(verbose);
-        return this;
-    }
+	/**
+	 * Creates an OptionBuilder instance with the default options:
+	 *
+	 * @param options
+	 *            Map of starting options. See {@link Options} for available
+	 *            keys
+	 *
+	 * @return options builder instance
+	 */
+	public static OptionsBuilder options(Map<String, Object> options) {
+		return new OptionsBuilder(options);
+	}
 
-    /**
-     * Sets the printErrors option
-     *
-     * @param printErrors true to enable error messages in the console
-     * @return updated OptionBuilder instance
-     *
-     * @see Options#PRINT_ERRORS
-     */
-    public OptionsBuilder printErrors(boolean printErrors) {
-        options.setPrintErrors(printErrors);
-        return this;
-    }
+	/**
+	 * Sets the offline option
+	 *
+	 * @param offline
+	 *            true to disable resolution of plugin from remote repositories
+	 * @return updated OptionBuilder instance
+	 * @see Options#OFFLINE
+	 */
+	public OptionsBuilder offline(boolean offline) {
+		options.setOffline(offline);
+		return this;
+	}
 
-    /**
-     * Sets the printErrors option
-     *
-     * @param throwException true to enable exception throwing
-     * @return updated OptionBuilder instance
-     *
-     * @see Options#PRINT_ERRORS
-     */
-    public OptionsBuilder throwException(boolean throwException) {
-        options.setThrowException(throwException);
-        return this;
-    }
+	/**
+	 * Sets the verbose option
+	 *
+	 * @param verbose
+	 *            true to enable info messages in the console
+	 * @return updated OptionBuilder instance
+	 *
+	 * @see Options#VERBOSE
+	 */
+	public OptionsBuilder verbose(boolean verbose) {
+		options.setVerbose(verbose);
+		return this;
+	}
 
-    /**
-     * Sets the includes option
-     *
-     * @param includes List of included paths
-     * @return updated OptionBuilder instance
-     *
-     * @see Options#INCLUDES
-     */
-    public OptionsBuilder includes(String... includes) {
-        options.setIncludes(includes);
-        return this;
-    }
+	/**
+	 * Sets the printErrors option
+	 *
+	 * @param printErrors
+	 *            true to enable error messages in the console
+	 * @return updated OptionBuilder instance
+	 *
+	 * @see Options#PRINT_ERRORS
+	 */
+	public OptionsBuilder printErrors(boolean printErrors) {
+		options.setPrintErrors(printErrors);
+		return this;
+	}
 
-    /**
-     * Sets the excludes
-     *
-     * @param excludes List of excluded paths
-     * @return updated OptionBuilder instance
-     *
-     * @see Options#EXCLUDES
-     */
-    public OptionsBuilder excludes(String... excludes) {
-        options.setExcludes(excludes);
-        return this;
-    }
+	/**
+	 * Sets the printErrors option
+	 *
+	 * @param throwException
+	 *            true to enable exception throwing
+	 * @return updated OptionBuilder instance
+	 *
+	 * @see Options#PRINT_ERRORS
+	 */
+	public OptionsBuilder throwException(boolean throwException) {
+		options.setThrowException(throwException);
+		return this;
+	}
 
-    /**
-     * Returns the stored options as a Map&lt;String,Object&gt;
-     *
-     * @return map with options
-     */
-    public Map<String, Object> asMap() {
-        return options.asMap();
-    }
+	/**
+	 * Sets the includes option
+	 *
+	 * @param includes
+	 *            List of included paths
+	 * @return updated OptionBuilder instance
+	 *
+	 * @see Options#INCLUDES
+	 */
+	public OptionsBuilder includes(String... includes) {
+		options.setIncludes(includes);
+		return this;
+	}
+
+	/**
+	 * Sets the excludes
+	 *
+	 * @param excludes
+	 *            List of excluded paths
+	 * @return updated OptionBuilder instance
+	 *
+	 * @see Options#EXCLUDES
+	 */
+	public OptionsBuilder excludes(String... excludes) {
+		options.setExcludes(excludes);
+		return this;
+	}
+
+
+	/**
+	 * 
+	 * @return the current built options
+	 */
+	public Options build(){
+		return options;
+	}
+	/**
+	 * Returns the stored options as a Map&lt;String,Object&gt;
+	 *
+	 * @return map with options
+	 */
+	public Map<String, Object> asMap() {
+		return options.asMap();
+	}
 
 }

--- a/src/main/java/org/walkmod/WalkModFacade.java
+++ b/src/main/java/org/walkmod/WalkModFacade.java
@@ -50,7 +50,7 @@ public class WalkModFacade {
 	private boolean verbose = true;
 
 	private boolean printError = false;
-	
+
 	private boolean throwsException = false;
 
 	private String[] includes;
@@ -80,7 +80,8 @@ public class WalkModFacade {
 	 * @param printError
 	 *            if the exception stack trace is printed in the System.out
 	 *
-	 * @deprecated Use #{link #WalkModFacade(File,OptionsBuilder, ConfigurationProvider} instead
+	 * @deprecated Use #{link #WalkModFacade(File,OptionsBuilder,
+	 *             ConfigurationProvider} instead
 	 */
 	public WalkModFacade(File cfg, boolean offline, boolean verbose,
 			boolean printError) {
@@ -107,7 +108,8 @@ public class WalkModFacade {
 	 * @param excludes
 	 *            the list of excluded files.
 	 *
-	 * @deprecated Use #{link #WalkModFacade(File,OptionsBuilder, ConfigurationProvider} instead
+	 * @deprecated Use #{link #WalkModFacade(File,OptionsBuilder,
+	 *             ConfigurationProvider} instead
 	 */
 	public WalkModFacade(File cfg, boolean offline, boolean verbose,
 			boolean printError, String[] includes, String[] excludes) {
@@ -131,7 +133,8 @@ public class WalkModFacade {
 	 * @param printError
 	 *            if the exception trace is printed in the System.out
 	 *
-	 * @deprecated Use #{link #WalkModFacade(File,OptionsBuilder, ConfigurationProvider} instead
+	 * @deprecated Use #{link #WalkModFacade(File,OptionsBuilder,
+	 *             ConfigurationProvider} instead
 	 */
 	public WalkModFacade(String cfg, boolean offline, boolean verbose,
 			boolean printError) {
@@ -154,14 +157,15 @@ public class WalkModFacade {
 	 * @param excludes
 	 *            the list of excluded files.
 	 *
-	 * @deprecated Use #{link #WalkModFacade(File,OptionsBuilder, ConfigurationProvider} instead
+	 * @deprecated Use #{link #WalkModFacade(File,OptionsBuilder,
+	 *             ConfigurationProvider} instead
 	 */
 	@Deprecated
 	public WalkModFacade(String cfg, boolean offline, boolean verbose,
 			boolean printError, String[] includes, String[] excludes) {
 		this(cfg, offline, verbose, printError, false, includes, excludes);
 	}
-	
+
 	/**
 	 * Facade constructor using the walkmod.xml configuration file.
 	 * 
@@ -179,12 +183,14 @@ public class WalkModFacade {
 	 *            the list of included files.
 	 * @param excludes
 	 *            the list of excluded files.
-     *
-	 * @deprecated Use #{link #WalkModFacade(File,OptionsBuilder, ConfigurationProvider} instead
+	 *
+	 * @deprecated Use #{link #WalkModFacade(File,OptionsBuilder,
+	 *             ConfigurationProvider} instead
 	 */
 	@Deprecated
 	public WalkModFacade(String cfg, boolean offline, boolean verbose,
-			boolean printError, boolean throwsException, String[] includes, String[] excludes) {
+			boolean printError, boolean throwsException, String[] includes,
+			String[] excludes) {
 		this.cfg = new File(cfg);
 		this.offline = offline;
 		this.verbose = verbose;
@@ -204,7 +210,8 @@ public class WalkModFacade {
 	 * @param printError
 	 *            if the exception trace is printed in the System.out
 	 *
-	 * @deprecated Use #{link #WalkModFacade(File,OptionsBuilder, ConfigurationProvider} instead
+	 * @deprecated Use #{link #WalkModFacade(File,OptionsBuilder,
+	 *             ConfigurationProvider} instead
 	 */
 	@Deprecated
 	public WalkModFacade(boolean offline, boolean verbose, boolean printError) {
@@ -225,7 +232,8 @@ public class WalkModFacade {
 	 * @param excludes
 	 *            the list of excluded files.
 	 *
-	 * @deprecated Use #{link #WalkModFacade(File,OptionsBuilder, ConfigurationProvider} instead
+	 * @deprecated Use #{link #WalkModFacade(File,OptionsBuilder,
+	 *             ConfigurationProvider} instead
 	 */
 	@Deprecated
 	public WalkModFacade(boolean offline, boolean verbose, boolean printError,
@@ -238,13 +246,13 @@ public class WalkModFacade {
 	 * Default facade constructor. It uses the walkmod.xml configuration file,
 	 * it is not off-line, it is verbose and doesn't print the exceptions' stack
 	 *
-	 * @deprecated Use #{link #WalkModFacade(File,OptionsBuilder, ConfigurationProvider} instead
+	 * @deprecated Use #{link #WalkModFacade(File,OptionsBuilder,
+	 *             ConfigurationProvider} instead
 	 */
 	@Deprecated
 	public WalkModFacade() {
 		this(false, true, false);
 	}
-
 
 	/**
 	 * Initalizes a Walkmod service
@@ -257,38 +265,40 @@ public class WalkModFacade {
 	 *            for available options and default values.
 	 * @param configurationProvider
 	 *            Configuration provider responsible for the resolution of
-	 *            plugins (used to use custom classloading strategies).
-	 *            If null Ivy is used.
+	 *            plugins (used to use custom classloading strategies). If null
+	 *            Ivy is used.
 	 */
-	public WalkModFacade(File walkmodCfg, OptionsBuilder optionsBuilder, ConfigurationProvider configurationProvider) {
+	public WalkModFacade(File walkmodCfg, OptionsBuilder optionsBuilder,
+			ConfigurationProvider configurationProvider) {
 
 		// process options
-		Map<String,Object> options = optionsBuilder.asMap();
-		if (options.containsKey(Options.OFFLINE))
-			this.offline = (Boolean) options.get(Options.OFFLINE);
-		if (options.containsKey(Options.VERBOSE))
-			this.verbose = (Boolean) options.get(Options.VERBOSE);
-		if (options.containsKey(Options.PRINT_ERRORS))
-			this.printError = (Boolean) options.get(Options.PRINT_ERRORS);
-		if (options.containsKey(Options.THROW_EXCEPTION))
-			this.throwsException = (Boolean) options.get(Options.THROW_EXCEPTION);
+		Options options = optionsBuilder.build();
 
-		if (options.containsKey(Options.INCLUDES))
-			this.includes = ((List<String>) options.get(Options.INCLUDES)).toArray(new String[]{});
-		if (options.containsKey(Options.EXCLUDES))
-			this.excludes = ((List<String>) options.get(Options.EXCLUDES)).toArray(new String[]{});
-
-		this.cfg = (walkmodCfg != null) ? walkmodCfg : new File(DEFAULT_WALKMOD_FILE);
+		this.offline = options.isOffline();
+		this.verbose = options.isVerbose();
+		this.printError = options.isPrintErrors();
+		this.throwsException = options.isThrowException();
+		List<String> includes = options.getIncludes();
+		if (includes != null) {
+			this.includes = includes.toArray(new String[includes.size()]);
+		}
+		List<String> excludes = options.getExcludes();
+		if(excludes != null){
+			this.excludes = excludes.toArray(new String[excludes.size()]);
+		}
+		
+		this.cfg = (walkmodCfg != null) ? walkmodCfg : new File(
+				DEFAULT_WALKMOD_FILE);
 
 		if (configurationProvider != null)
 			this.configurationProvider = configurationProvider;
 	}
 
-
 	/**
 	 * Takes care of chosing the proper configuration provider
 	 *
-	 * NOTE: this is a first pass, handling a default provider should be improved
+	 * NOTE: this is a first pass, handling a default provider should be
+	 * improved
 	 */
 	private ConfigurationProvider locateConfigurationProvider() {
 		if (configurationProvider == null)
@@ -434,8 +444,7 @@ public class WalkModFacade {
 
 	/**
 	 * Downloads the list of declared plugins in the configuration file using
-	 * Ivy.
-	 * Ignores the ConfigurationProvided if passed in the constructor.
+	 * Ivy. Ignores the ConfigurationProvided if passed in the constructor.
 	 * 
 	 * @throws InvalidConfigurationException
 	 *             if the walkmod configuration is invalid and it is working in
@@ -543,7 +552,7 @@ public class WalkModFacade {
 			if (verbose) {
 				log.error(cfg.getAbsolutePath()
 						+ " does not exist. The root directory of your project must contain a walkmod.xml");
-				
+
 			} else {
 				throw new WalkModException(
 						cfg.getAbsolutePath()

--- a/src/test/java/org/walkmod/OptionsTest.java
+++ b/src/test/java/org/walkmod/OptionsTest.java
@@ -1,14 +1,16 @@
 package org.walkmod;
 
-import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import org.junit.Test;
 
 /**
  * Tests for {@link Options} and {@link OptionsBuilder}
@@ -16,10 +18,16 @@ import static org.hamcrest.Matchers.*;
 public class OptionsTest {
 
     @Test
-    public void options_does_not_initialize_values() {
-        Options _options = new Options();
-        Map<String,Object> options = _options.asMap();
-        assertThat(options.values(), is(empty()));
+    public void options_initialize_default_values() {
+        Options options = new Options();
+        
+        assertThat(options.isOffline(), is(false));
+        assertThat(options.isVerbose(), is(true));
+        assertThat(options.isPrintErrors(), is(false));
+        assertThat(options.isThrowException(), is(false));
+        assertThat(options.getExcludes(), is(nullValue()));
+        assertThat(options.getIncludes(), is(nullValue()));
+       
     }
 
     @Test
@@ -31,111 +39,103 @@ public class OptionsTest {
 
         Options _options = new Options(myOptions);
         Map<String,Object> options = _options.asMap();
-        assertThat(options.values().size(), is(3));
-        assertThat(((List<String>) options.get(Options.INCLUDES)).size(), is(3));
-        assertThat((Boolean) options.get(Options.OFFLINE), is(true));
-        assertThat((Boolean) options.get(Options.THROW_EXCEPTION), is(true));
-        assertThat((List<String>) options.get(Options.INCLUDES), contains("one/path", "two/path", "three/path"));
+        assertThat(options.values().size(), is(5)); //default values(4) + includes
+        assertThat(_options.getIncludes().size(), is(3));
+        assertThat(_options.isOffline(), is(true));
+        assertThat(_options.isThrowException(), is(true));
+        assertThat(_options.getIncludes(), contains("one/path", "two/path", "three/path"));
     }
 
     @Test
     public void offline_option_setter_works() {
         Options options = new Options();
-        Boolean value = (Boolean)options.asMap().get(Options.OFFLINE);
-        assertThat(value, is(nullValue()));
-
+       
         options.setOffline(true);
-        assertThat((Boolean) options.asMap().get(Options.OFFLINE), is(true));
+        assertThat(options.isOffline(), is(true));
 
         options.setOffline(false);
-        assertThat((Boolean) options.asMap().get(Options.OFFLINE), is(false));
+        assertThat(options.isOffline(), is(false));
     }
 
     @Test
     public void verbose_option_setter_works() {
         Options options = new Options();
-        Boolean value = (Boolean)options.asMap().get(Options.VERBOSE);
-        assertThat(value, is(nullValue()));
-
+      
         options.setVerbose(true);
-        assertThat((Boolean) options.asMap().get(Options.VERBOSE), is(true));
+        assertThat(options.isVerbose(), is(true));
 
         options.setVerbose(false);
-        assertThat((Boolean) options.asMap().get(Options.VERBOSE), is(false));
+        assertThat(options.isVerbose(), is(false));
     }
 
     @Test
     public void printErrors_option_setter_works() {
         Options options = new Options();
-        Boolean value = (Boolean)options.asMap().get(Options.PRINT_ERRORS);
-        assertThat(value, is(nullValue()));
-
+       
         options.setPrintErrors(true);
-        assertThat((Boolean) options.asMap().get(Options.PRINT_ERRORS), is(true));
+        assertThat(options.isPrintErrors(), is(true));
 
         options.setPrintErrors(false);
-        assertThat((Boolean) options.asMap().get(Options.PRINT_ERRORS), is(false));
+        assertThat(options.isPrintErrors(), is(false));
     }
 
     @Test
     public void throwsException_option_setter_works() {
         Options options = new Options();
-        Boolean value = (Boolean)options.asMap().get(Options.THROW_EXCEPTION);
-        assertThat(value, is(nullValue()));
-
+        
         options.setThrowException(true);
-        assertThat((Boolean) options.asMap().get(Options.THROW_EXCEPTION), is(true));
+        assertThat(options.isThrowException(), is(true));
 
         options.setThrowException(false);
-        assertThat((Boolean) options.asMap().get(Options.THROW_EXCEPTION), is(false));
+        assertThat(options.isThrowException(), is(false));
     }
 
     @Test
     public void include_option_setter_multiple_works() {
         Options options = new Options();
-        Object previousValue = options.asMap().get(Options.INCLUDES);
+        Object previousValue = options.getIncludes();
         assertThat(previousValue, is(nullValue()));
 
         options.setIncludes("one", "two", "path/three");
-        assertThat(((List<String>) options.asMap().get(Options.INCLUDES)).size(), is(3));
-        assertThat((List<String>) options.asMap().get(Options.INCLUDES), contains("one", "two", "path/three"));
+        assertThat(options.getIncludes().size(), is(3));
+        assertThat(options.getIncludes(), contains("one", "two", "path/three"));
     }
 
     @Test
     public void include_option_setter_one_by_one_works() {
         Options options = new Options();
-        Object previousValue = options.asMap().get(Options.INCLUDES);
+        Object previousValue = options.getIncludes();
         assertThat(previousValue, is(nullValue()));
 
         options.setIncludes("one");
         options.setIncludes("two");
         options.setIncludes( "path/three");
-        assertThat(((List<String>) options.asMap().get(Options.INCLUDES)).size(), is(3));
-        assertThat((List<String>) options.asMap().get(Options.INCLUDES), contains("one", "two", "path/three"));
+        assertThat(options.getIncludes().size(), is(3));
+        assertThat(options.getIncludes(), contains("one", "two", "path/three"));
     }
 
     @Test
     public void exclude_option_setter_multiple_works() {
         Options options = new Options();
-        Object previousValue = options.asMap().get(Options.EXCLUDES);
+        Object previousValue = options.getExcludes();
         assertThat(previousValue, is(nullValue()));
 
         options.setExcludes("one", "two", "path/three");
-        assertThat(((List<String>) options.asMap().get(Options.EXCLUDES)).size(), is(3));
-        assertThat((List<String>) options.asMap().get(Options.EXCLUDES), contains("one", "two", "path/three"));
+        assertThat(options.getExcludes().size(), is(3));
+        assertThat(options.getExcludes(), contains("one", "two", "path/three"));
     }
 
     @Test
     public void exclude_option_setter_one_by_one_works() {
         Options options = new Options();
-        Object previousValue = options.asMap().get(Options.EXCLUDES);
+        Object previousValue = options.getExcludes();
         assertThat(previousValue, is(nullValue()));
 
         options.setExcludes("one");
         options.setExcludes("two");
         options.setExcludes("path/three");
-        assertThat(((List<String>) options.asMap().get(Options.EXCLUDES)).size(), is(3));
-        assertThat((List<String>) options.asMap().get(Options.EXCLUDES), contains("one", "two", "path/three"));
+        assertThat(options.getExcludes().size(), is(3));
+        assertThat(options.getExcludes(), contains("one", "two", "path/three"));
     }
 
     /**
@@ -145,15 +145,15 @@ public class OptionsTest {
     public void optionsBuilder_initializes_options_values() {
 
         OptionsBuilder builder = OptionsBuilder.options();
-        Map<String,Object> options = builder.asMap();
+        Options options = builder.build();
 
-        assertThat((Boolean) options.get(Options.OFFLINE), is(false));
-        assertThat((Boolean) options.get(Options.VERBOSE), is(true));
-        assertThat((Boolean) options.get(Options.PRINT_ERRORS), is(false));
-        assertThat((Boolean) options.get(Options.THROW_EXCEPTION), is(false));
+        assertThat(options.isOffline(), is(false));
+        assertThat(options.isVerbose(), is(true));
+        assertThat(options.isPrintErrors(), is(false));
+        assertThat(options.isThrowException(), is(false));
 
-        assertThat(options.get(Options.INCLUDES), is(nullValue()));
-        assertThat(options.get(Options.EXCLUDES), is(nullValue()));
+        assertThat(options.getIncludes(), is(nullValue()));
+        assertThat(options.getExcludes(), is(nullValue()));
     }
 
     @Test
@@ -164,17 +164,17 @@ public class OptionsTest {
         myOptions.put(Options.VERBOSE, false);
 
         OptionsBuilder builder = OptionsBuilder.options(myOptions);
-        Map<String,Object> options = builder.asMap();
+        Options options = builder.build();
 
         // Values from myOptions map
-        assertThat((Boolean) options.get(Options.OFFLINE), is(true));
-        assertThat((Boolean) options.get(Options.VERBOSE), is(false));
+        assertThat(options.isOffline(), is(true));
+        assertThat(options.isVerbose(), is(false));
         // Default values are also set
-        assertThat((Boolean) options.get(Options.PRINT_ERRORS), is(false));
-        assertThat((Boolean) options.get(Options.THROW_EXCEPTION), is(false));
+        assertThat(options.isPrintErrors(), is(false));
+        assertThat(options.isThrowException(), is(false));
 
-        assertThat(options.get(Options.INCLUDES), is(nullValue()));
-        assertThat(options.get(Options.EXCLUDES), is(nullValue()));
+        assertThat(options.getIncludes(), is(nullValue()));
+        assertThat(options.getExcludes(), is(nullValue()));
 
         // Added test for PRINT_ERRORS and THROW_EXCEPTION just for coverage
         myOptions = new HashMap<String, Object>();
@@ -182,17 +182,17 @@ public class OptionsTest {
         myOptions.put(Options.THROW_EXCEPTION, true);
 
         builder = OptionsBuilder.options(myOptions);
-        options = builder.asMap();
+        options = builder.build();
 
         // Values from myOptions map
-        assertThat((Boolean) options.get(Options.OFFLINE), is(false));
-        assertThat((Boolean) options.get(Options.VERBOSE), is(true));
+        assertThat(options.isOffline(), is(false));
+        assertThat(options.isVerbose(), is(true));
         // Default values are also set
-        assertThat((Boolean) options.get(Options.PRINT_ERRORS), is(true));
-        assertThat((Boolean) options.get(Options.THROW_EXCEPTION), is(true));
+        assertThat(options.isPrintErrors(), is(true));
+        assertThat(options.isThrowException(), is(true));
 
-        assertThat(options.get(Options.INCLUDES), is(nullValue()));
-        assertThat(options.get(Options.EXCLUDES), is(nullValue()));
+        assertThat(options.getIncludes(), is(nullValue()));
+        assertThat(options.getExcludes(), is(nullValue()));
     }
 
     @Test
@@ -200,28 +200,28 @@ public class OptionsTest {
 
         OptionsBuilder builder = OptionsBuilder.options().offline(true).verbose(false).includes("one", "two");
         builder.throwException(true);
-        Map<String, Object> options = builder.asMap();
+        Options options = builder.build();
 
-        assertThat((Boolean) options.get(Options.OFFLINE), is(true));
-        assertThat((Boolean) options.get(Options.VERBOSE), is(false));
-        assertThat((Boolean) options.get(Options.PRINT_ERRORS), is(false));
-        assertThat((Boolean) options.get(Options.THROW_EXCEPTION), is(true));
+        assertThat(options.isOffline(), is(true));
+        assertThat(options.isVerbose(), is(false));
+        assertThat(options.isPrintErrors(), is(false));
+        assertThat(options.isThrowException(), is(true));
 
-        assertThat((List<String>) options.get(Options.INCLUDES), contains("one","two"));
-        assertThat(options.get(Options.EXCLUDES), is(nullValue()));
+        assertThat(options.getIncludes(), contains("one","two"));
+        assertThat(options.getExcludes(), is(nullValue()));
 
 
         // Added test for printErrors and exclude just for coverage
         builder = OptionsBuilder.options().printErrors(true).excludes("three", "four");
-        options = builder.asMap();
+        options = builder.build();
 
-        assertThat((Boolean) options.get(Options.OFFLINE), is(false));
-        assertThat((Boolean) options.get(Options.VERBOSE), is(true));
-        assertThat((Boolean) options.get(Options.PRINT_ERRORS), is(true));
-        assertThat((Boolean) options.get(Options.THROW_EXCEPTION), is(false));
+        assertThat(options.isOffline(), is(false));
+        assertThat(options.isVerbose(), is(true));
+        assertThat(options.isPrintErrors(), is(true));
+        assertThat(options.isThrowException(), is(false));
 
-        assertThat(options.get(Options.INCLUDES), is(nullValue()));
-        assertThat((List<String>) options.get(Options.EXCLUDES), contains("three","four"));
+        assertThat(options.getIncludes(), is(nullValue()));
+        assertThat(options.getExcludes(), contains("three","four"));
     }
 
 }


### PR DESCRIPTION
I have added getters into the `Options` class to avoid navigations through the Map. It allows to write less code to read the options and manage 'scenarios' if the key exists or not.

Also, the default options are initialized into the `Options` class to avoid bugs in any future component that also use this class (even the tests works for the builder). 